### PR TITLE
fix: correct power of c in Hawking radiation rate

### DIFF
--- a/theory/quantum-theory-math.md
+++ b/theory/quantum-theory-math.md
@@ -286,7 +286,7 @@ The coupling constant γ² = 0.364840  emerges from:
 ## VII. Physical Applications
 
 1. Black Hole Evolution:
-   - Mass loss rate: dM/dt = -ℏc⁶/(15360πG²M²)
+   - Mass loss rate: dM/dt = -ℏc⁴/(15360πG²M²)
    - Temperature: T = T_H(1 - β/2)
    - Entropy: S = S_BH(1 + γ_eff*ln(A/ℓ_P²))
 


### PR DESCRIPTION
dM/dt = -ℏc⁴/(15360πG²M²)

- Fix dimensional analysis [M/T]
- Match Stefan-Boltzmann law
- Better match evaporation timescales"